### PR TITLE
feat(ttl): životnosť správ (TTL) + „zhasínanie“ + lokálny scheduler

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -64,6 +64,8 @@ dependencies {
     implementation(libs.coil.compose)
     implementation(libs.kotlinx.coroutines.android)
     implementation(libs.lifecycle.runtime.compose)
+    implementation(libs.compose.animation)
+
 }
 
 ktlint {

--- a/app/src/main/java/app/quantumsocial/ui/screens/WishScreen.kt
+++ b/app/src/main/java/app/quantumsocial/ui/screens/WishScreen.kt
@@ -45,7 +45,11 @@ fun WishScreen() {
         }
 
         LazyColumn {
-            items(signals, key = Signal::id) { s -> WishNetCard(signal = s) }
+            items(signals, key = Signal::id) { s ->
+                WishNetCard(signal = s) { read ->
+                    app.quantumsocial.core.data.InMemorySignalRepository.markRead(read.id)
+                }
+            }
         }
     }
 }

--- a/app/src/main/java/app/quantumsocial/ui/signals/WishNetCard.kt
+++ b/app/src/main/java/app/quantumsocial/ui/signals/WishNetCard.kt
@@ -1,13 +1,21 @@
 package app.quantumsocial.ui.signals
 
 import android.net.Uri
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkVertically
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.produceState
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.unit.dp
 import app.quantumsocial.core.model.AudioSignal
 import app.quantumsocial.core.model.EmojiSignal
@@ -15,37 +23,78 @@ import app.quantumsocial.core.model.FlashSignal
 import app.quantumsocial.core.model.ImageSignal
 import app.quantumsocial.core.model.MixSignal
 import app.quantumsocial.core.model.Signal
+import app.quantumsocial.core.model.SignalCategory
 import app.quantumsocial.core.model.TextSignal
 import coil.compose.AsyncImage
+import kotlinx.coroutines.delay
 
 @Composable
-fun WishNetCard(signal: Signal) {
-    Card(
-        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp),
-        modifier = Modifier.padding(8.dp),
+fun WishNetCard(
+    signal: Signal,
+    onRead: (Signal) -> Unit,
+) {
+    val now by produceState(initialValue = System.currentTimeMillis(), signal.id) {
+        while (true) {
+            value = System.currentTimeMillis()
+            delay(500)
+        }
+    }
+    val remaining = signal.remainingMillis(now)
+    val expiringWindow = 5_000L
+    val isExpiring = remaining != null && remaining in 1..expiringWindow
+
+    val alpha by animateFloatAsState(
+        targetValue = if (isExpiring) (remaining!!.toFloat() / expiringWindow).coerceIn(0.2f, 1f) else 1f,
+        label = "fade-out",
+    )
+
+    AnimatedVisibility(
+        visible = !signal.isExpired(now),
+        exit = fadeOut() + shrinkVertically(),
     ) {
-        Column(Modifier.padding(12.dp)) {
-            Text(text = signal::class.simpleName ?: "Signal")
-            when (signal) {
-                is TextSignal -> Text(signal.text, modifier = Modifier.padding(top = 6.dp))
-                is EmojiSignal -> Text(signal.emoji, modifier = Modifier.padding(top = 6.dp))
-                is ImageSignal ->
-                    AsyncImage(
-                        model = Uri.parse(signal.imageUri),
-                        contentDescription = "obrázok",
-                        modifier = Modifier.padding(top = 6.dp),
-                    )
-                is AudioSignal ->
-                    Text(
-                        "🎧 Audio: ${signal.durationMs / 1000}s",
-                        modifier = Modifier.padding(top = 6.dp),
-                    )
-                is FlashSignal ->
-                    Text(
-                        "⚡ Záblesk: ${(signal.intensity * 100).toInt()}%",
-                        modifier = Modifier.padding(top = 6.dp),
-                    )
-                is MixSignal -> Text("Mix ${signal.parts.size} prvkov", modifier = Modifier.padding(top = 6.dp))
+        Card(
+            elevation = CardDefaults.cardElevation(defaultElevation = 2.dp),
+            modifier =
+                Modifier
+                    .padding(8.dp)
+                    .alpha(alpha)
+                    .clickable { onRead(signal) },
+        ) {
+            Column(Modifier.padding(12.dp)) {
+                val badge =
+                    when (signal.category) {
+                        SignalCategory.Ephemeral -> "⏳ mizne"
+                        SignalCategory.WishNet -> "💫 WishNet"
+                    }
+                Text("$badge • ${signal::class.simpleName}")
+
+                when (signal) {
+                    is TextSignal -> Text(signal.text, modifier = Modifier.padding(top = 6.dp))
+                    is EmojiSignal -> Text(signal.emoji, modifier = Modifier.padding(top = 6.dp))
+                    is ImageSignal ->
+                        AsyncImage(
+                            model = Uri.parse(signal.imageUri),
+                            contentDescription = "obrázok",
+                            modifier = Modifier.padding(top = 6.dp),
+                        )
+                    is AudioSignal ->
+                        Text(
+                            "🎧 Audio: ${signal.durationMs / 1000}s",
+                            modifier = Modifier.padding(top = 6.dp),
+                        )
+                    is FlashSignal ->
+                        Text(
+                            "⚡ Záblesk: ${(signal.intensity * 100).toInt()}%",
+                            modifier = Modifier.padding(top = 6.dp),
+                        )
+                    is MixSignal -> Text("Mix ${signal.parts.size} prvkov", modifier = Modifier.padding(top = 6.dp))
+                }
+
+                remaining?.let {
+                    if (it > 0) {
+                        Text("Zostáva: ${it / 1000}s", modifier = Modifier.padding(top = 6.dp))
+                    }
+                }
             }
         }
     }

--- a/core/src/main/java/app/quantumsocial/core/data/InMemorySignalRepository.kt
+++ b/core/src/main/java/app/quantumsocial/core/data/InMemorySignalRepository.kt
@@ -1,16 +1,48 @@
 package app.quantumsocial.core.data
 
 import app.quantumsocial.core.model.Signal
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
 
 object InMemorySignalRepository {
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+
     private val _signals = MutableStateFlow<List<Signal>>(emptyList())
     val signals: StateFlow<List<Signal>> = _signals.asStateFlow()
 
+    init {
+        scope.launch {
+            while (isActive) {
+                val now = System.currentTimeMillis()
+                val filtered = _signals.value.filterNot { it.isExpired(now) }
+                if (filtered.size != _signals.value.size) _signals.value = filtered
+                delay(1_000)
+            }
+        }
+    }
+
     fun send(signal: Signal) {
-        // Najnovšie hore
         _signals.value = listOf(signal) + _signals.value
+    }
+
+    fun markRead(id: String) {
+        val s = _signals.value.firstOrNull { it.id == id } ?: return
+        if (s.expireOnRead) _signals.value = _signals.value.filterNot { it.id == id }
+    }
+
+    fun clear() {
+        _signals.value = emptyList()
+    }
+
+    fun shutdown() {
+        scope.cancel()
     }
 }

--- a/core/src/main/java/app/quantumsocial/core/model/Signal.kt
+++ b/core/src/main/java/app/quantumsocial/core/model/Signal.kt
@@ -2,51 +2,80 @@ package app.quantumsocial.core.model
 
 import java.util.UUID
 
+enum class SignalCategory { Ephemeral, WishNet }
+
 sealed interface Signal {
     val id: String
     val createdAt: Long
+    val category: SignalCategory
+    val expireOnRead: Boolean
+    val ttlMillis: Long?
+
+    val expiresAt: Long? get() = ttlMillis?.let { createdAt + it }
+
+    fun remainingMillis(now: Long = System.currentTimeMillis()): Long? = expiresAt?.let { it - now }
+
+    fun isExpired(now: Long = System.currentTimeMillis()): Boolean = remainingMillis(now)?.let { it <= 0 } ?: false
 }
 
-/** Textový signál (max 200 znakov sa kontroluje v UI). */
+/** Text (max 200 znakov sa kontroluje v UI). */
 data class TextSignal(
     val text: String,
     override val id: String = UUID.randomUUID().toString(),
     override val createdAt: Long = System.currentTimeMillis(),
+    override val category: SignalCategory = SignalCategory.Ephemeral,
+    override val expireOnRead: Boolean = true,
+    override val ttlMillis: Long? = 30_000L,
 ) : Signal
 
-/** Emodži signál – jedna emoji. */
+/** Jedna emoji. */
 data class EmojiSignal(
     val emoji: String,
     override val id: String = UUID.randomUUID().toString(),
     override val createdAt: Long = System.currentTimeMillis(),
+    override val category: SignalCategory = SignalCategory.Ephemeral,
+    override val expireOnRead: Boolean = true,
+    override val ttlMillis: Long? = 30_000L,
 ) : Signal
 
-/** Audio signál – cesta k súboru a dĺžka v ms (limit 15 s sa rieši v UI). */
+/** Audio: cesta k súboru + dĺžka v ms (limit nahrávania rieši UI). */
 data class AudioSignal(
     val filePath: String,
     val durationMs: Int,
     override val id: String = UUID.randomUUID().toString(),
     override val createdAt: Long = System.currentTimeMillis(),
+    override val category: SignalCategory = SignalCategory.Ephemeral,
+    override val expireOnRead: Boolean = true,
+    override val ttlMillis: Long? = 60_000L,
 ) : Signal
 
-/** Obrázkový signál – URI obrázka (Photo Picker). */
+/** Obrázok: URI reťazec (Photo Picker). */
 data class ImageSignal(
     val imageUri: String,
     override val id: String = UUID.randomUUID().toString(),
     override val createdAt: Long = System.currentTimeMillis(),
+    override val category: SignalCategory = SignalCategory.Ephemeral,
+    override val expireOnRead: Boolean = true,
+    override val ttlMillis: Long? = 60_000L,
 ) : Signal
 
-/** Svetelný záblesk – intenzita 0f..1f a trvanie v ms. */
+/** Svetelný záblesk. */
 data class FlashSignal(
     val intensity: Float,
     val durationMs: Int = 300,
     override val id: String = UUID.randomUUID().toString(),
     override val createdAt: Long = System.currentTimeMillis(),
+    override val category: SignalCategory = SignalCategory.Ephemeral,
+    override val expireOnRead: Boolean = true,
+    override val ttlMillis: Long? = 15_000L,
 ) : Signal
 
-/** Mix viacerých signálov. */
+/** Mix – špeciálny (WishNet), neexpiruje čítaním, dlho trvá. */
 data class MixSignal(
     val parts: List<Signal>,
     override val id: String = UUID.randomUUID().toString(),
     override val createdAt: Long = System.currentTimeMillis(),
+    override val category: SignalCategory = SignalCategory.WishNet,
+    override val expireOnRead: Boolean = false,
+    override val ttlMillis: Long? = 86_400_000L,
 ) : Signal

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,6 +24,7 @@ compose-bom = { module = "androidx.compose:compose-bom", version.ref = "compose-
 compose-ui = { module = "androidx.compose.ui:ui" }
 compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview" }
 compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling" }
+compose-animation = { module = "androidx.compose.animation:animation" }
 material3 = { module = "androidx.compose.material3:material3" }
 activity-compose = { module = "androidx.activity:activity-compose", version.ref = "activity-compose" }
 core-ktx = { module = "androidx.core:core-ktx", version.ref = "core-ktx" }


### PR DESCRIPTION
## Čo sa mení
- Pridané TTL/kategórie do modelov (`Signal`, `Text/Emoji/Audio/Image/Flash/MixSignal`)
- Jednoduchý lokálny „scheduler“ v `InMemorySignalRepository` (čistenie expirovaných 1×/s)
- „Zhasínanie“ (fade-out) a odpočet v kartičke `WishNetCard`
- Kliknutie na kartu = markRead (ephemeral správy miznú hneď)
- Odstránené wildcard importy, uprataný štýl (ktlint zelený)

## Prečo
Chceme simulovať efemérne správy lokálne: bežné správy miznú po čase/čítaní, špeciálne (WishNet) vydržia dlhšie.

## Ako overiť (manuálne)
1. Spusti app → Wish tabu.
2. Pošli **Text/Emoji/Flash** → majú badge „⏳ mizne“, posledných ~5 s blednú a zmiznú.
3. Pošli **Mix** → badge „💫 WishNet“, **nezmizne klikom**, má dlhé TTL.
4. Klik na ktorúkoľvek **ephemeral** kartu → zmizne okamžite (expireOnRead).

## Kontrola kvality
- [ ] `./gradlew ktlintCheck` prejde lokálne
- [ ] `./gradlew assembleDebug` prejde lokálne
- [ ] GitHub Actions (Android CI) zelené
- [ ] Vizuál galaxie/animácia neporušené

## Riziká
- Žiadna perzistencia (zatiaľ iba in-memory).
- TTL hodnoty sú demo (30–60 s/24 h) – neskôr nastavíme podľa produktu.

## Poznámky
- Vetva: `krok3-clean` → cieľ: `main`
